### PR TITLE
Fix broken categories links

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -33,7 +33,7 @@ layout: compress
             {% assign categories = page.categories %}
           {% endif %}
           {% for category in categories %}
-            <a class="label" href="{{site.baseurl | relative_url}}categories/#{{category|slugize}}">{{category}}</a>
+            <a class="label" href="{{site.baseurl}}categories/#{{category|slugize}}">{{category}}</a>
             {% unless forloop.last %}&nbsp;{% endunless %}
           {% endfor %}
         </div>


### PR DESCRIPTION
Fix them again because the last fix was wrong.