### PR TITLE
Change site.baseurl to a relative_url

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -34,6 +34,7 @@ layout: compress
           {% endif %}
           {% for category in categories %}
             <a class="label" href="{{site.baseurl}}categories/#{{category|slugize}}">{{category}}</a>
+            <span>{{"/" | relative_url}}categories/#{{category|slugize}}</span>
             {% unless forloop.last %}&nbsp;{% endunless %}
           {% endfor %}
         </div>


### PR DESCRIPTION
We may be running into https://github.com/github/pages-gem/issues/460 which is breaking our category links, but just on GitHub pages. Giving this change a try to see if so.